### PR TITLE
Add support for querying Global Secondary Indexes which have no range…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ organization in ThisBuild := "com.github.dwhjames"
 
 licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion in ThisBuild := "2.11.6"
+scalaVersion in ThisBuild := "2.11.7"
 
-crossScalaVersions in ThisBuild := Seq("2.10.5", "2.11.6")
+crossScalaVersions in ThisBuild := Seq("2.10.5", "2.11.7")
 
 scalacOptions in ThisBuild ++= Seq(
     "-deprecation",

--- a/integration/src/it/scala/dynamodb/GameScore.scala
+++ b/integration/src/it/scala/dynamodb/GameScore.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 Daniel W. H. James
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dwhjames.awswrap.dynamodb
+
+import com.amazonaws.services.dynamodbv2.model._
+
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+
+case class GameScore(
+    userId:           String,
+    gameTitle:        String,
+    topScore:         Long,
+    topScoreDateTime: DateTime,
+    wins:             Long,
+    losses:           Long
+)
+
+object GameScore {
+
+  val tableName = "GameScores"
+  val globalSecondaryIndexName = "GameTitleIndex"
+
+  val tableRequest =
+    new CreateTableRequest()
+    .withTableName(GameScore.tableName)
+    .withProvisionedThroughput(Schema.provisionedThroughput(10L, 5L))
+    .withAttributeDefinitions(
+      Schema.stringAttribute(Attributes.userId),
+      Schema.stringAttribute(Attributes.gameTitle),
+      Schema.numberAttribute(Attributes.topScore)
+    )
+    .withKeySchema(
+      Schema.hashKey(Attributes.userId),
+      Schema.rangeKey(Attributes.gameTitle)
+    )
+    .withGlobalSecondaryIndexes(
+      new GlobalSecondaryIndex()
+      .withIndexName(GameScore.globalSecondaryIndexName)
+      .withProvisionedThroughput(Schema.provisionedThroughput(10L, 5L))
+      .withKeySchema(
+        Schema.hashKey(Attributes.gameTitle),
+        Schema.rangeKey(Attributes.topScore)
+      )
+      .withProjection(
+        new Projection()
+        .withProjectionType(ProjectionType.KEYS_ONLY)
+      )
+    )
+
+  object Attributes {
+    val userId           = "UserId"
+    val gameTitle        = "GameTitle"
+    val topScore         = "TopScore"
+    val topScoreDateTime = "TopScoreDateTime"
+    val wins             = "Wins"
+    val losses           = "Losses"
+  }
+
+  implicit object sameScoreSerializer extends DynamoDBSerializer[GameScore] {
+    private val fmt = ISODateTimeFormat.dateTime
+
+    override val tableName = GameScore.tableName
+    override val hashAttributeName = Attributes.userId
+    override val rangeAttributeName = Some(Attributes.gameTitle)
+
+    override def primaryKeyOf(score: GameScore) =
+      Map(
+        Attributes.userId    -> score.userId,
+        Attributes.gameTitle -> score.gameTitle
+      )
+
+    override def toAttributeMap(score: GameScore) =
+      Map(
+        Attributes.userId           -> score.userId,
+        Attributes.gameTitle        -> score.gameTitle,
+        Attributes.topScore         -> score.topScore,
+        Attributes.topScoreDateTime -> fmt.print(score.topScoreDateTime),
+        Attributes.wins             -> score.wins,
+        Attributes.losses           -> score.losses
+      )
+
+    override def fromAttributeMap(item: collection.mutable.Map[String, AttributeValue]) =
+      GameScore(
+        userId           = item(Attributes.userId),
+        gameTitle        = item(Attributes.gameTitle),
+        topScore         = item(Attributes.topScore),
+        topScoreDateTime = fmt.parseDateTime(item(Attributes.topScoreDateTime)),
+        wins             = item(Attributes.wins),
+        losses           = item(Attributes.losses)
+      )
+  }
+}

--- a/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
+++ b/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
@@ -75,6 +75,19 @@ class QueryGlobalSecondaryIndexSpec
     result should have size (2)
     result(0).userId should equal ("101")
     result(1).userId should equal ("103")
-  }
 
+    val result2 = await {
+      mapper.queryOnce[GameScore](
+        GameScore.globalSecondaryIndexName,
+        GameScore.Attributes.gameTitle,
+        "Galaxy Invaders",
+        Some(GameScore.Attributes.topScore -> QueryCondition.greaterThan(0)),
+        false,
+        10 // top ten high scores
+      )
+    }
+    result2 should have size (2)
+    result2(0).userId should equal ("101")
+    result2(1).userId should equal ("103")
+  }
 }

--- a/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
+++ b/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Daniel W. H. James
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dwhjames.awswrap.dynamodb
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+import org.scalatest.{ FlatSpec, BeforeAndAfterAll, Matchers }
+
+import com.amazonaws.AmazonClientException
+
+
+class QueryGlobalSecondaryIndexSpec
+  extends FlatSpec
+     with Matchers
+     with DynamoDBClient
+{
+  import SampleData.sampleGameScores
+
+  override val tableNames = Seq(GameScore.tableName)
+
+  val mapper = AmazonDynamoDBScalaMapper(client)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    tryCreateTable(GameScore.tableRequest)
+    awaitTableCreation(GameScore.tableName)
+
+    await(30.seconds) {
+      mapper.batchDump(sampleGameScores)
+    }
+  }
+
+  "DynamoDB" should s"contain the '${GameScore.tableName}' table" in {
+    val result = await(1.minutes) {
+      client.listTables()
+    }
+
+    result.getTableNames().asScala should contain (GameScore.tableName)
+  }
+
+  it should s"contain ${sampleGameScores.size} game score items" in {
+    await {
+      mapper.countScan[GameScore]()
+    } should equal (sampleGameScores.size)
+  }
+
+  it should s"return top ten high scores using global secondary index" in {
+    val result = await {
+      mapper.query[GameScore](
+                  GameScore.globalSecondaryIndexName,
+                  GameScore.Attributes.gameTitle,
+                  "Galaxy Invaders",
+                  Some(GameScore.Attributes.topScore -> QueryCondition.greaterThan(0)),
+                  false,
+                  10 // top ten high scores
+                )
+    }
+    result should have size (2)
+    result(0).userId should equal ("101")
+    result(1).userId should equal ("103")
+  }
+
+}

--- a/integration/src/it/scala/dynamodb/SampleData.scala
+++ b/integration/src/it/scala/dynamodb/SampleData.scala
@@ -106,4 +106,81 @@ object SampleData {
         postedBy      = "User A"
       )
     )
+
+  val sampleGameScores: Seq[GameScore] = Seq(
+      GameScore(
+        userId = "101",
+        gameTitle = "Galaxy Invaders",
+        topScore = 5842,
+        topScoreDateTime = DateTime.now.minusDays(1),
+        wins = 21,
+        losses = 72
+      ),
+      GameScore(
+        userId = "101",
+        gameTitle = "Meteor Blasters",
+        topScore = 1000,
+        topScoreDateTime = DateTime.now.minusDays(2),
+        wins = 12,
+        losses = 3
+      ),
+      GameScore(
+        userId = "101",
+        gameTitle = "Starship X",
+        topScore = 24,
+        topScoreDateTime = DateTime.now.minusDays(3),
+        wins = 4,
+        losses = 9
+      ),
+
+      GameScore(
+        userId = "102",
+        gameTitle = "Alien Adventure",
+        topScore = 192,
+        topScoreDateTime = DateTime.now.minusDays(4),
+        wins = 32,
+        losses = 192
+      ),
+      GameScore(
+        userId = "102",
+        gameTitle = "Galaxy Invaders",
+        topScore = 0,
+        topScoreDateTime = DateTime.now.minusDays(5),
+        wins = 0,
+        losses = 5
+      ),
+
+      GameScore(
+        userId = "103",
+        gameTitle = "Attack Ships",
+        topScore = 3,
+        topScoreDateTime = DateTime.now.minusDays(6),
+        wins = 1,
+        losses = 8
+      ),
+      GameScore(
+        userId = "103",
+        gameTitle = "Galaxy Invaders",
+        topScore = 2317,
+        topScoreDateTime = DateTime.now.minusDays(7),
+        wins = 40,
+        losses = 3
+      ),
+      GameScore(
+        userId = "103",
+        gameTitle = "Meteor Blasters",
+        topScore = 723,
+        topScoreDateTime = DateTime.now.minusDays(8),
+        wins = 22,
+        losses = 12
+      ),
+      GameScore(
+        userId = "103",
+        gameTitle = "Starship X",
+        topScore = 42,
+        topScoreDateTime = DateTime.now.minusDays(9),
+        wins = 4,
+        losses = 19
+      )
+    )
 }


### PR DESCRIPTION
Could not see a way of querying global secondary indexes so I have created a new method queryOnGlobalSecondaryIndex that allows you to specify the index name, attribute name and an optional  range condition.

As an aside can I ask how you run the integration tests from sbt? I can't seem to figure it out.

Thanks