### PR TITLE
update aws-java-sdk to 1.10.67

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object V {
-    val awsJavaSDK  = "1.10.32"
+    val awsJavaSDK  = "1.10.67"
 
     val jodaTime    = "2.9"
     val jodaConvert = "1.8"

--- a/src/main/scala/sns/sns.scala
+++ b/src/main/scala/sns/sns.scala
@@ -30,12 +30,18 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def addPermissionAsync(
     addPermissionAsyncRequest: AddPermissionRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.addPermissionAsync, addPermissionAsyncRequest)
+    wrapVoidAsyncMethod[AddPermissionRequest](
+      client.addPermissionAsync,
+      addPermissionAsyncRequest
+    )
 
   def confirmSubscription(
     confirmSubscriptionRequest: ConfirmSubscriptionRequest
   ): Future[ConfirmSubscriptionResult] =
-    wrapAsyncMethod(client.confirmSubscriptionAsync, confirmSubscriptionRequest)
+    wrapAsyncMethod[ConfirmSubscriptionRequest, ConfirmSubscriptionResult](
+      client.confirmSubscriptionAsync,
+      confirmSubscriptionRequest
+    )
 
   def confirmSubscription(
     topicArn: String,
@@ -46,7 +52,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def createTopic(
     createTopicRequest: CreateTopicRequest
   ): Future[CreateTopicResult] =
-    wrapAsyncMethod(client.createTopicAsync, createTopicRequest)
+    wrapAsyncMethod[CreateTopicRequest, CreateTopicResult](
+      client.createTopicAsync,
+      createTopicRequest
+    )
 
   def createTopic(
     name: String
@@ -56,7 +65,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def deleteTopic(
     deleteTopicRequest: DeleteTopicRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.deleteTopicAsync, deleteTopicRequest)
+    wrapVoidAsyncMethod[DeleteTopicRequest](
+      client.deleteTopicAsync,
+      deleteTopicRequest
+    )
 
   def deleteTopic(
     topicArn: String
@@ -72,7 +84,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def getSubscriptionAttributes(
     getSubscriptionAttributesRequest: GetSubscriptionAttributesRequest
   ): Future[GetSubscriptionAttributesResult] =
-    wrapAsyncMethod(client.getSubscriptionAttributesAsync, getSubscriptionAttributesRequest)
+    wrapAsyncMethod[GetSubscriptionAttributesRequest, GetSubscriptionAttributesResult](
+      client.getSubscriptionAttributesAsync,
+      getSubscriptionAttributesRequest
+    )
 
   def getSubscriptionAttributes(
     subsciptionArn: String
@@ -80,7 +95,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
     getSubscriptionAttributes(new GetSubscriptionAttributesRequest(subsciptionArn))
 
   def getTopicAttributes(getTopicAttributesRequest: GetTopicAttributesRequest): Future[GetTopicAttributesResult] =
-    wrapAsyncMethod(client.getTopicAttributesAsync, getTopicAttributesRequest)
+    wrapAsyncMethod[GetTopicAttributesRequest, GetTopicAttributesResult](
+      client.getTopicAttributesAsync,
+      getTopicAttributesRequest
+    )
 
   def getTopicAttributes(
     topicArn: String
@@ -90,7 +108,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def listSubscriptions(
     listSubscriptionsRequest: ListSubscriptionsRequest
   ): Future[ListSubscriptionsResult] =
-    wrapAsyncMethod(client.listSubscriptionsAsync, listSubscriptionsRequest)
+    wrapAsyncMethod[ListSubscriptionsRequest, ListSubscriptionsResult](
+      client.listSubscriptionsAsync,
+      listSubscriptionsRequest
+    )
 
   def listSubscriptions(
     nextToken: String = null
@@ -100,7 +121,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def listSubscriptionsByTopic(
     listSubscriptionsByTopicRequest: ListSubscriptionsByTopicRequest
   ): Future[ListSubscriptionsByTopicResult] =
-      wrapAsyncMethod(client.listSubscriptionsByTopicAsync, listSubscriptionsByTopicRequest)
+      wrapAsyncMethod[ListSubscriptionsByTopicRequest, ListSubscriptionsByTopicResult](
+        client.listSubscriptionsByTopicAsync,
+        listSubscriptionsByTopicRequest
+      )
 
   def listSubscriptionsByTopic(
     topicArn:  String,
@@ -111,7 +135,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def listTopics(
     listTopicsRequest: ListTopicsRequest
   ): Future[ListTopicsResult] =
-    wrapAsyncMethod(client.listTopicsAsync, listTopicsRequest)
+    wrapAsyncMethod[ListTopicsRequest, ListTopicsResult](
+      client.listTopicsAsync,
+      listTopicsRequest
+    )
 
   def listTopics(
     nextToken: String = null
@@ -121,7 +148,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def publish(
     publishRequest: PublishRequest
   ): Future[PublishResult] =
-    wrapAsyncMethod(client.publishAsync, publishRequest)
+    wrapAsyncMethod[PublishRequest, PublishResult](
+      client.publishAsync,
+      publishRequest
+    )
 
   def publish(
     topicArn: String,
@@ -132,17 +162,26 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def removePermission(
     removePermissionRequest: RemovePermissionRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.removePermissionAsync, removePermissionRequest)
+    wrapVoidAsyncMethod[RemovePermissionRequest](
+      client.removePermissionAsync,
+      removePermissionRequest
+    )
 
   def setSubscriptionAttributes(
     setSubscriptionAttributesRequest: SetSubscriptionAttributesRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.setSubscriptionAttributesAsync, setSubscriptionAttributesRequest)
+    wrapVoidAsyncMethod[SetSubscriptionAttributesRequest](
+      client.setSubscriptionAttributesAsync,
+      setSubscriptionAttributesRequest
+    )
 
   def setTopicAttributes(
     setTopicAttributesRequest: SetTopicAttributesRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.setTopicAttributesAsync, setTopicAttributesRequest)
+    wrapVoidAsyncMethod[SetTopicAttributesRequest](
+      client.setTopicAttributesAsync,
+      setTopicAttributesRequest
+    )
 
   def shutdown(): Unit =
     client.shutdown()
@@ -150,7 +189,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def subscribe(
     subscribeRequest: SubscribeRequest
   ): Future[SubscribeResult] =
-    wrapAsyncMethod(client.subscribeAsync, subscribeRequest)
+    wrapAsyncMethod[SubscribeRequest, SubscribeResult](
+      client.subscribeAsync,
+      subscribeRequest
+    )
 
   def subscribe(
     topicArn: String,
@@ -162,7 +204,10 @@ class AmazonSNSScalaClient(val client: AmazonSNSAsyncClient) {
   def unsubscribe(
     unsubscribeRequest: UnsubscribeRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.unsubscribeAsync, unsubscribeRequest)
+    wrapVoidAsyncMethod[UnsubscribeRequest](
+      client.unsubscribeAsync,
+      unsubscribeRequest
+    )
 
   def unsubscribe(
     subsciptionArn: String

--- a/src/main/scala/sqs/sqs.scala
+++ b/src/main/scala/sqs/sqs.scala
@@ -34,7 +34,10 @@ class AmazonSQSScalaClient(
   def addPermission(
     addPermissionRequest: AddPermissionRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.addPermissionAsync, addPermissionRequest)
+    wrapVoidAsyncMethod[AddPermissionRequest](
+      client.addPermissionAsync,
+      addPermissionRequest
+    )
 
   def addPermission(
     queueUrl:       String,
@@ -55,7 +58,10 @@ class AmazonSQSScalaClient(
   def changeMessageVisibility(
     changeMessageVisibilityRequest: ChangeMessageVisibilityRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.changeMessageVisibilityAsync, changeMessageVisibilityRequest)
+    wrapVoidAsyncMethod[ChangeMessageVisibilityRequest](
+      client.changeMessageVisibilityAsync,
+      changeMessageVisibilityRequest
+    )
 
   def changeMessageVisibility(
     queueUrl:          String,
@@ -67,7 +73,10 @@ class AmazonSQSScalaClient(
   def changeMessageVisibilityBatch(
     changeMessageVisibilityBatchRequest: ChangeMessageVisibilityBatchRequest
   ): Future[ChangeMessageVisibilityBatchResult] =
-    wrapAsyncMethod(client.changeMessageVisibilityBatchAsync, changeMessageVisibilityBatchRequest)
+    wrapAsyncMethod[ChangeMessageVisibilityBatchRequest, ChangeMessageVisibilityBatchResult](
+      client.changeMessageVisibilityBatchAsync,
+      changeMessageVisibilityBatchRequest
+    )
 
   def changeMessageVisibilityBatch(
     queueUrl:            String,
@@ -86,7 +95,10 @@ class AmazonSQSScalaClient(
   def createQueue(
     createQueueRequest: CreateQueueRequest
   ): Future[CreateQueueResult] =
-    wrapAsyncMethod(client.createQueueAsync, createQueueRequest)
+    wrapAsyncMethod[CreateQueueRequest, CreateQueueResult](
+      client.createQueueAsync,
+      createQueueRequest
+    )
 
   def createQueue(
     queueName: String,
@@ -104,7 +116,10 @@ class AmazonSQSScalaClient(
   def deleteMessage(
     deleteMessageRequest: DeleteMessageRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.deleteMessageAsync, deleteMessageRequest)
+    wrapVoidAsyncMethod[DeleteMessageRequest](
+      client.deleteMessageAsync,
+      deleteMessageRequest
+    )
 
   def deleteMessage(
     queueUrl:      String,
@@ -115,7 +130,10 @@ class AmazonSQSScalaClient(
   def deleteMessageBatch(
     deleteMessageBatchRequest: DeleteMessageBatchRequest
   ): Future[DeleteMessageBatchResult] =
-    wrapAsyncMethod(client.deleteMessageBatchAsync, deleteMessageBatchRequest)
+    wrapAsyncMethod[DeleteMessageBatchRequest, DeleteMessageBatchResult](
+      client.deleteMessageBatchAsync,
+      deleteMessageBatchRequest
+    )
 
   def deleteMessageBatch(
     queueUrl: String,
@@ -133,7 +151,10 @@ class AmazonSQSScalaClient(
   def deleteQueue(
     deleteQueueRequest: DeleteQueueRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.deleteQueueAsync, deleteQueueRequest)
+    wrapVoidAsyncMethod[DeleteQueueRequest](
+      client.deleteQueueAsync,
+      deleteQueueRequest
+    )
 
   def deleteQueue(
     queueUrl: String
@@ -146,7 +167,10 @@ class AmazonSQSScalaClient(
   def getQueueAttributes(
     getQueueAttributesRequest: GetQueueAttributesRequest
   ): Future[GetQueueAttributesResult] =
-    wrapAsyncMethod(client.getQueueAttributesAsync, getQueueAttributesRequest)
+    wrapAsyncMethod[GetQueueAttributesRequest, GetQueueAttributesResult](
+      client.getQueueAttributesAsync,
+      getQueueAttributesRequest
+    )
 
   def getQueueAttributes(
     queueUrl: String,
@@ -160,7 +184,10 @@ class AmazonSQSScalaClient(
   def getQueueUrl(
     getQueueUrlRequest: GetQueueUrlRequest
   ): Future[GetQueueUrlResult] =
-    wrapAsyncMethod(client.getQueueUrlAsync, getQueueUrlRequest)
+    wrapAsyncMethod[GetQueueUrlRequest, GetQueueUrlResult](
+      client.getQueueUrlAsync,
+      getQueueUrlRequest
+    )
 
   def getQueueUrl(
     queueName: String
@@ -170,7 +197,10 @@ class AmazonSQSScalaClient(
   def listQueues(
     listQueuesRequest: ListQueuesRequest
   ): Future[ListQueuesResult] =
-    wrapAsyncMethod(client.listQueuesAsync, listQueuesRequest)
+    wrapAsyncMethod[ListQueuesRequest, ListQueuesResult](
+      client.listQueuesAsync,
+      listQueuesRequest
+    )
 
   def listQueues(
     queueNamePrefix: String = null
@@ -180,7 +210,10 @@ class AmazonSQSScalaClient(
   def receiveMessage(
     receiveMessageRequest: ReceiveMessageRequest
   ): Future[ReceiveMessageResult] =
-    wrapAsyncMethod(client.receiveMessageAsync, receiveMessageRequest)
+    wrapAsyncMethod[ReceiveMessageRequest, ReceiveMessageResult](
+      client.receiveMessageAsync,
+      receiveMessageRequest
+    )
 
   def receiveMessage(
     queueUrl: String
@@ -199,7 +232,10 @@ class AmazonSQSScalaClient(
   def removePermission(
     removePermissionRequest: RemovePermissionRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.removePermissionAsync, removePermissionRequest)
+    wrapVoidAsyncMethod[RemovePermissionRequest](
+      client.removePermissionAsync,
+      removePermissionRequest
+    )
 
   def removePermission(
     queueUrl: String,
@@ -210,7 +246,10 @@ class AmazonSQSScalaClient(
   def sendMessage(
     sendMessageRequest: SendMessageRequest
   ): Future[SendMessageResult] =
-    wrapAsyncMethod(client.sendMessageAsync, sendMessageRequest)
+    wrapAsyncMethod[SendMessageRequest, SendMessageResult](
+      client.sendMessageAsync,
+      sendMessageRequest
+    )
 
   def sendMessage(
     queueUrl:    String,
@@ -221,7 +260,10 @@ class AmazonSQSScalaClient(
   def sendMessageBatch(
     sendMessageBatchRequest: SendMessageBatchRequest
   ): Future[SendMessageBatchResult] =
-    wrapAsyncMethod(client.sendMessageBatchAsync, sendMessageBatchRequest)
+    wrapAsyncMethod[SendMessageBatchRequest, SendMessageBatchResult](
+      client.sendMessageBatchAsync,
+      sendMessageBatchRequest
+    )
 
   def sendMessageBatch(
     queueUrl: String,
@@ -239,7 +281,10 @@ class AmazonSQSScalaClient(
   def setQueueAttributes(
     setQueueAttributesRequest: SetQueueAttributesRequest
   ): Future[Unit] =
-    wrapVoidAsyncMethod(client.setQueueAttributesAsync, setQueueAttributesRequest)
+    wrapVoidAsyncMethod[SetQueueAttributesRequest](
+      client.setQueueAttributesAsync,
+      setQueueAttributesRequest
+    )
 
   def setQueueAttributes(
     queueUrl:   String,


### PR DESCRIPTION
- Patch update on the aws-java-sdk dependency. Includes bug fixes, one of them is related to XML parsing of the S3 request when there are weird or otherwise non-standard characters in the object filenames.
- Updated sns.scala's and sqs.scala's many invocations of wrapVoidAsyncMethod and wrapAsyncMethod
  - added explicit type parameters
    - this is so that the compilier can differentiate between the various client.xxx methods
  - Updated aws-jdk-sdk has additional invocations for each original client.xxx method
- These code changes, while trivial, resulted in verbose, long code. To keep with styling conventions, I dropped the parameters for the wrapAsync\* method invocations to separate new-lines.
