### PR TITLE
Scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/LICE
 
 scalaVersion in ThisBuild := "2.11.7"
 
-crossScalaVersions in ThisBuild := Seq("2.10.5", "2.11.7")
+crossScalaVersions in ThisBuild := Seq("2.10.5", "2.11.7", "2.12.1")
 
 shellPrompt in ThisBuild := CustomShellPrompt.customPrompt
 

--- a/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
+++ b/integration/src/it/scala/dynamodb/GlobalSecondaryIndexSpec.scala
@@ -16,13 +16,11 @@
 
 package com.github.dwhjames.awswrap.dynamodb
 
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-
-import org.scalatest.{ FlatSpec, BeforeAndAfterAll, Matchers }
-
-import com.amazonaws.AmazonClientException
 
 
 class QueryGlobalSecondaryIndexSpec

--- a/integration/src/it/scala/dynamodb/ReadsOnHashKeyTablesSpec.scala
+++ b/integration/src/it/scala/dynamodb/ReadsOnHashKeyTablesSpec.scala
@@ -17,13 +17,11 @@
 
 package com.github.dwhjames.awswrap.dynamodb
 
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-
-import org.scalatest.{ FlatSpec, BeforeAndAfterAll, Matchers }
-
-import com.amazonaws.AmazonClientException
 
 
 class ReadsOnHashKeyTableSpec

--- a/integration/src/it/scala/s3/FutureTransferSpec.scala
+++ b/integration/src/it/scala/s3/FutureTransferSpec.scala
@@ -17,13 +17,9 @@
 package com.github.dwhjames.awswrap
 package s3
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 import java.io.File
 
 import org.scalatest.{ FlatSpec, Matchers }
-
-import com.amazonaws.AmazonClientException
 
 
 class FutureTransferSpec

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,6 @@ object Dependencies {
 
   object IntegrationTest {
 
-    val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % "it"
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % "it"
   }
 }

--- a/src/main/scala/dynamodb/SingleThreadedBatchWriter.scala
+++ b/src/main/scala/dynamodb/SingleThreadedBatchWriter.scala
@@ -20,8 +20,8 @@ package com.github.dwhjames.awswrap.dynamodb
 import java.{util => ju}
 import java.util.Random
 
-import com.amazonaws.{AmazonClientException, AmazonServiceException, ClientConfiguration}
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.{AmazonServiceException, ClientConfiguration}
+import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider}
 import com.amazonaws.internal.StaticCredentialsProvider
 import com.amazonaws.retry.RetryUtils
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient

--- a/src/main/scala/s3/s3.scala
+++ b/src/main/scala/s3/s3.scala
@@ -22,13 +22,13 @@ import java.io.{InputStream, File}
 import java.net.URL
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 import java.util.concurrent.{Executors, ExecutorService, ThreadFactory}
 import java.util.concurrent.atomic.AtomicLong
 
-import com.amazonaws.{AmazonWebServiceRequest, ClientConfiguration}
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.event.{ProgressListener, ProgressEvent, ProgressEventType}
 import com.amazonaws.internal.StaticCredentialsProvider;


### PR DESCRIPTION
This PR adds Scala 2.12.1 to the supported compilers. 
Had to remove some unused imports make it compile, no other change was necessary.